### PR TITLE
feat!: move BQ project/dataset/table to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ At the end of a workflow call this action to send ci analytics to big query
 ```yaml
 - uses: reside-eng/workflow-ci-analytics-action@v1
   with:
+    # Google project ID where to send data
+    #
+    # Required: true
+    project_id: ''
+
+    # Bigquery dataset where to send data
+    #
+    # Required: true
+    dataset: ''
+
+    # Bigquery table where to send data
+    #
+    # Required: true
+    table: ''
+
     # Timestamp when the job was created
     #
     # Required: true

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,15 @@
 name: 'Workflow CI Analytics'
 description: 'Send Github Data Analytics to the Data Warehouse'
 inputs:
+  project_id:
+    description: 'Google project ID where to send data'
+    required: true
+  dataset:
+    description: 'Bigquery dataset where to send data'
+    required: true
+  table:
+    description: 'Bigquery table where to send data'
+    required: true
   created_at:
     description: 'Timestamp when the job was created'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -68014,6 +68014,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Inputs = void 0;
 var Inputs;
 (function (Inputs) {
+    Inputs["ProjectId"] = "project_id";
+    Inputs["Dataset"] = "dataset";
+    Inputs["Table"] = "table";
     Inputs["CreatedAt"] = "created_at";
     Inputs["StartedAt"] = "started_at";
     Inputs["CompletedAt"] = "completed_at";
@@ -68077,7 +68080,7 @@ const core = __importStar(__nccwpck_require__(7484));
 const github_1 = __nccwpck_require__(3228);
 const bigquery_1 = __nccwpck_require__(676);
 const inputs_1 = __nccwpck_require__(8422);
-async function sendToBigQuery(analyticsObject) {
+async function sendToBigQuery(analyticsObject, projectId, datasetName, tableName) {
     const client = new bigquery_1.BigQuery();
     const schema = 'Created_At:string, Started_At:string, Completed_At:string, MatrixName:string, MatrixValue:string, Result:string, Draft:boolean, JobLink:string';
     const options = {
@@ -68090,13 +68093,16 @@ async function sendToBigQuery(analyticsObject) {
         },
     };
     const table = await client
-        .dataset('github', { projectId: 'side-dw' })
-        .table('ci_analytics');
+        .dataset(datasetName, { projectId })
+        .table(tableName);
     core.info(`Retrieved table ${table.id}`);
     table.insert(analyticsObject);
 }
 async function pipeline() {
     core.info('Successfully triggering CI Analytics action');
+    const projectId = core.getInput(inputs_1.Inputs.ProjectId, { required: true });
+    const dataset = core.getInput(inputs_1.Inputs.Dataset, { required: true });
+    const table = core.getInput(inputs_1.Inputs.Table, { required: true });
     const createdAt = core.getInput(inputs_1.Inputs.CreatedAt, { required: true });
     const startedAt = core.getInput(inputs_1.Inputs.StartedAt, { required: true });
     const completedAt = core.getInput(inputs_1.Inputs.CompletedAt, { required: true });
@@ -68152,7 +68158,7 @@ async function pipeline() {
     };
     core.info('Analytics Object: ');
     core.info(JSON.stringify(analyticsObject, null, 2));
-    await sendToBigQuery(analyticsObject);
+    await sendToBigQuery(analyticsObject, projectId, dataset, table);
     core.info('Successfully Set CI Analytics in bigquery');
 }
 function handleError(err) {

--- a/dist/inputs.d.ts
+++ b/dist/inputs.d.ts
@@ -1,4 +1,7 @@
 export declare enum Inputs {
+    ProjectId = "project_id",
+    Dataset = "dataset",
+    Table = "table",
     CreatedAt = "created_at",
     StartedAt = "started_at",
     CompletedAt = "completed_at",

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,4 +1,7 @@
 export enum Inputs {
+  ProjectId = 'project_id',
+  Dataset = 'dataset',
+  Table = 'table',
   CreatedAt = 'created_at',
   StartedAt = 'started_at',
   CompletedAt = 'completed_at',

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -53,6 +53,12 @@ describe('GitHub Action - CI Analytics', () => {
       .mockImplementation((name: string) => {
         if (Object.values(Inputs).includes(name as Inputs)) {
           switch (name) {
+            case Inputs.ProjectId:
+              return 'test';
+            case Inputs.Dataset:
+              return 'github';
+            case Inputs.Table:
+              return 'ci_analytics';
             case Inputs.CreatedAt:
               return mockExpectedAnalytics.created_at;
             case Inputs.StartedAt:
@@ -145,7 +151,7 @@ describe('GitHub Action - CI Analytics', () => {
 
     // Validate BigQuery interaction
     expect(bigQueryMock.dataset).toHaveBeenCalledWith('github', {
-      projectId: 'side-dw',
+      projectId: 'test',
     });
     expect(datasetMock.table).toHaveBeenCalledWith('ci_analytics');
     expect(insertMock).toHaveBeenCalledWith(mockExpectedAnalytics);

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,12 @@ export type AnalyticsObject = {
   runner_type: string;
 };
 
-async function sendToBigQuery(analyticsObject: AnalyticsObject): Promise<void> {
+async function sendToBigQuery(
+  analyticsObject: AnalyticsObject,
+  projectId: string,
+  datasetName: string,
+  tableName: string,
+): Promise<void> {
   const client = new BigQuery();
 
   const schema =
@@ -48,8 +53,8 @@ async function sendToBigQuery(analyticsObject: AnalyticsObject): Promise<void> {
 
   // Create a new table in the dataset
   const table = await client
-    .dataset('github', { projectId: 'side-dw' })
-    .table('ci_analytics');
+    .dataset(datasetName, { projectId })
+    .table(tableName);
 
   core.info(`Retrieved table ${table.id}`);
 
@@ -61,6 +66,9 @@ async function sendToBigQuery(analyticsObject: AnalyticsObject): Promise<void> {
  */
 async function pipeline(): Promise<void> {
   core.info('Successfully triggering CI Analytics action');
+  const projectId = core.getInput(Inputs.ProjectId, { required: true });
+  const dataset = core.getInput(Inputs.Dataset, { required: true });
+  const table = core.getInput(Inputs.Table, { required: true });
   const createdAt = core.getInput(Inputs.CreatedAt, { required: true });
   const startedAt = core.getInput(Inputs.StartedAt, { required: true });
   const completedAt = core.getInput(Inputs.CompletedAt, { required: true });
@@ -139,7 +147,7 @@ async function pipeline(): Promise<void> {
   core.info('Analytics Object: ');
   core.info(JSON.stringify(analyticsObject, null, 2));
 
-  await sendToBigQuery(analyticsObject);
+  await sendToBigQuery(analyticsObject, projectId, dataset, table);
   core.info('Successfully Set CI Analytics in bigquery');
 }
 


### PR DESCRIPTION
These changes are about making our custom action more generic so it can be used by anybody to send their CI analytics data to their own BQ dataset.

We'll then make this custom action public. This is required for the CI analytics to be used in our public repo CI.

BREAKING CHANGE: We now require the BQ project/dataset/table to be provided as inputs.

:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
