### PR TITLE
chore(yarn): add age-gate config mirroring renovate trusted-org policy

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,15 @@
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 14d
+
+npmPreapprovedPackages:
+  - "@side/*"
+  - "@google/*"
+  - "google-*"
+  - "@datadog/*"
+  - "next"
+  - "react"
+  - "react-dom"
+  - "@yarnpkg/cli"
+
 yarnPath: .yarn/releases/yarn-4.15.0.cjs


### PR DESCRIPTION
## Context

Yarn 4.15.0 enables [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) by default at `1d`. Yesterday's batched `@side/*` releases hit this gate and broke Renovate PRs (raised in https://top-agent.slack.com/archives/C0B5164BG5R/p1779999854258089). This repo was skipped in the original fan-out (working tree was dirty).

## Change

**`.yarnrc.yml`** — mirror Renovate's trusted-org age-gate policy ([renovate-config/default.json:58-69](https://github.com/reside-eng/renovate-config/blob/main/default.json#L58-L69)): `npmMinimalAgeGate: 14d` + `npmPreapprovedPackages` (`@side/*`, `@google/*`, `google-*`, `@datadog/*`, `next`, `react`, `react-dom`, `@yarnpkg/cli`).

No CODEOWNERS change — this repo is `* @reside-eng/devops`, so a `.yarnrc.yml @reside-eng/devops` line would be a no-op (devops already owns everything).

## Pilot

Same change landed first in https://github.com/reside-eng/core-service/pull/6430.